### PR TITLE
feat: sync highlight animation, reduce glow, add post-processing effe…

### DIFF
--- a/src/components/canvas/HighlightShaderMaterial.tsx
+++ b/src/components/canvas/HighlightShaderMaterial.tsx
@@ -7,7 +7,7 @@ const HighlightShaderMaterial = shaderMaterial(
     uTime: 0,
     uPixelRatio: 1,
     uSize: 0.5,
-    uBrightness: 1.6,       // color boost (not pure white — keeps original hue)
+    uBrightness: 1.15,      // color boost (subtle — keeps original hue)
     uSweepSpeed: 0.8,       // how fast the light band sweeps
     uSweepWidth: 2.0,       // width of the sweep band
   },
@@ -23,9 +23,16 @@ const HighlightShaderMaterial = shaderMaterial(
 
     void main() {
       vColor = color;
-      vWorldPos = position;
 
-      vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+      vec3 pos = position;
+
+      // Match base model wave animation exactly
+      float wave = sin(uTime * 0.8 + pos.x * 0.3 + pos.y * 0.3) * 0.02;
+      pos.y += wave;
+
+      vWorldPos = pos;
+
+      vec4 mvPosition = modelViewMatrix * vec4(pos, 1.0);
       gl_Position = projectionMatrix * mvPosition;
 
       // Size attenuation (match base model)
@@ -69,7 +76,7 @@ const HighlightShaderMaterial = shaderMaterial(
 
       // Base highlight: original color * brightness
       // Sweep adds extra glow on top
-      float totalBright = uBrightness + sweepIntensity * 1.5;
+      float totalBright = uBrightness + sweepIntensity * 0.6;
       vec3 glowColor = vColor * totalBright;
 
       // Soft edge for additive blending

--- a/src/components/canvas/Scene.tsx
+++ b/src/components/canvas/Scene.tsx
@@ -2,7 +2,9 @@
 
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
-import { EffectComposer, Bloom } from '@react-three/postprocessing'
+import { EffectComposer, Bloom, Vignette, ChromaticAberration, TiltShift } from '@react-three/postprocessing'
+import { BlendFunction } from 'postprocessing'
+import * as THREE from 'three'
 import { Suspense, Component, type ReactNode } from 'react'
 import { useStore } from '@/store'
 import { PointCloud } from './PointCloud'
@@ -39,6 +41,14 @@ function getHlUrl(baseUrl: string): string {
 
 function SceneContent() {
     const { activeMemoryId, memories } = useStore((s) => s)
+    const vignetteEnabled = useStore((s) => s.vignetteEnabled)
+    const vignetteIntensity = useStore((s) => s.vignetteIntensity)
+    const chromaticEnabled = useStore((s) => s.chromaticEnabled)
+    const chromaticIntensity = useStore((s) => s.chromaticIntensity)
+    const edgeBlurEnabled = useStore((s) => s.edgeBlurEnabled)
+    const edgeBlurIntensity = useStore((s) => s.edgeBlurIntensity)
+    const bloomEnabled = useStore((s) => s.bloomEnabled)
+    const bloomIntensity = useStore((s) => s.bloomIntensity)
     const activeMemory = memories.find((m) => m.id === activeMemoryId)
 
     if (!activeMemory || !activeMemory.model_url) return null
@@ -70,10 +80,28 @@ function SceneContent() {
             ))}
             <EffectComposer>
                 <Bloom
-                    intensity={0.25}
-                    luminanceThreshold={0.9}
-                    luminanceSmoothing={0.3}
+                    intensity={bloomEnabled ? bloomIntensity : 0}
+                    luminanceThreshold={1.2}
+                    luminanceSmoothing={0.4}
                     mipmapBlur
+                />
+                <Vignette
+                    offset={0.3}
+                    darkness={vignetteEnabled ? vignetteIntensity : 0}
+                    blendFunction={BlendFunction.NORMAL}
+                />
+                <ChromaticAberration
+                    offset={new THREE.Vector2(
+                        chromaticEnabled ? chromaticIntensity : 0,
+                        chromaticEnabled ? chromaticIntensity : 0
+                    )}
+                    radialModulation
+                    modulationOffset={0.2}
+                />
+                <TiltShift
+                    blur={edgeBlurEnabled ? edgeBlurIntensity : 0}
+                    focusArea={0.5}
+                    feather={0.3}
                 />
             </EffectComposer>
             <CoordPicker />

--- a/src/components/dom/DebugPanel.tsx
+++ b/src/components/dom/DebugPanel.tsx
@@ -16,6 +16,14 @@ export function DebugPanel() {
         hlFullSample,
         raycastMode,
         pickedCoord,
+        vignetteEnabled,
+        vignetteIntensity,
+        chromaticEnabled,
+        chromaticIntensity,
+        edgeBlurEnabled,
+        edgeBlurIntensity,
+        bloomEnabled,
+        bloomIntensity,
         set,
     } = useStore((s) => s)
 
@@ -104,6 +112,63 @@ export function DebugPanel() {
                             </div>
                         </div>
 
+                        {/* Effects */}
+                        <div className="px-4 py-3 space-y-4 border-b border-white/5">
+                            <span className="text-[10px] text-white/30 uppercase tracking-widest">Effects</span>
+
+                            {/* Bloom */}
+                            <EffectControl
+                                label="Bloom"
+                                enabled={bloomEnabled}
+                                onToggle={() => set({ bloomEnabled: !bloomEnabled })}
+                                value={bloomIntensity}
+                                min={0.01}
+                                max={1.0}
+                                step={0.01}
+                                displayValue={bloomIntensity.toFixed(2)}
+                                onChange={(v) => set({ bloomIntensity: v })}
+                            />
+
+                            {/* Vignette */}
+                            <EffectControl
+                                label="Vignette"
+                                enabled={vignetteEnabled}
+                                onToggle={() => set({ vignetteEnabled: !vignetteEnabled })}
+                                value={vignetteIntensity}
+                                min={0.05}
+                                max={1.5}
+                                step={0.05}
+                                displayValue={vignetteIntensity.toFixed(2)}
+                                onChange={(v) => set({ vignetteIntensity: v })}
+                            />
+
+                            {/* Chromatic Aberration */}
+                            <EffectControl
+                                label="Chromatic"
+                                enabled={chromaticEnabled}
+                                onToggle={() => set({ chromaticEnabled: !chromaticEnabled })}
+                                value={chromaticIntensity}
+                                min={0.0005}
+                                max={0.02}
+                                step={0.0005}
+                                displayValue={chromaticIntensity.toFixed(4)}
+                                onChange={(v) => set({ chromaticIntensity: v })}
+                            />
+
+                            {/* Edge Blur */}
+                            <EffectControl
+                                label="Edge Blur"
+                                enabled={edgeBlurEnabled}
+                                onToggle={() => set({ edgeBlurEnabled: !edgeBlurEnabled })}
+                                value={edgeBlurIntensity}
+                                min={0.05}
+                                max={3.0}
+                                step={0.05}
+                                displayValue={edgeBlurIntensity.toFixed(2)}
+                                onChange={(v) => set({ edgeBlurIntensity: v })}
+                            />
+                        </div>
+
                         {/* Coord Picker */}
                         <div className="px-4 py-3 space-y-3">
                             <div className="flex items-center justify-between">
@@ -172,8 +237,8 @@ function SliderControl({
 }) {
     return (
         <div>
-            <div className="flex items-center justify-between mb-1.5">
-                <span className="text-[11px] text-white/40 uppercase tracking-wide">{label}</span>
+            <div className={`flex items-center justify-between ${label ? 'mb-1.5' : 'mb-0.5 justify-end'}`}>
+                {label && <span className="text-[11px] text-white/40 uppercase tracking-wide">{label}</span>}
                 <span className="text-xs font-mono text-white/70">{displayValue}</span>
             </div>
             <input
@@ -193,6 +258,45 @@ function SliderControl({
                     [&::-webkit-slider-thumb]:transition-colors
                     [&::-webkit-slider-thumb]:shadow-md"
             />
+        </div>
+    )
+}
+
+function EffectControl({
+    label, enabled, onToggle, value, min, max, step, displayValue, onChange
+}: {
+    label: string
+    enabled: boolean
+    onToggle: () => void
+    value: number
+    min: number
+    max: number
+    step: number
+    displayValue: string
+    onChange: (v: number) => void
+}) {
+    return (
+        <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+                <span className="text-[11px] text-white/40 uppercase tracking-wide">{label}</span>
+                <button
+                    onClick={onToggle}
+                    className={`w-8 h-4 rounded-full transition-colors duration-200 cursor-pointer ${enabled ? 'bg-emerald-500/60' : 'bg-white/10'}`}
+                >
+                    <div className={`w-3 h-3 rounded-full bg-white shadow-sm transition-transform duration-200 ${enabled ? 'translate-x-4.5' : 'translate-x-0.5'}`} />
+                </button>
+            </div>
+            {enabled && (
+                <SliderControl
+                    label=""
+                    value={value}
+                    min={min}
+                    max={max}
+                    step={step}
+                    displayValue={displayValue}
+                    onChange={onChange}
+                />
+            )}
         </div>
     )
 }

--- a/src/data/memories.json
+++ b/src/data/memories.json
@@ -54,9 +54,9 @@
         "tiles": [
             {
                 "position": [
-                    -0.4425,
-                    0.6293,
-                    2.2977
+                    0.5196,
+                    -0.1707,
+                    -0.3407
                 ],
                 "label": "Cat Scratches",
                 "description": "The leather fabric of the sofa has undergone long-term cutting and friction, leaving behind high-frequency, irregular reticulated scratches. This stems from the repeated stretching and scratching of a domestic cat. It is an accumulated physical proof of long-term biological companionship and daily behavior."

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -35,6 +35,16 @@ interface AppState {
     // Info tiles
     activeTileId: string | null
 
+    // Post-processing effects
+    vignetteEnabled: boolean
+    vignetteIntensity: number
+    chromaticEnabled: boolean
+    chromaticIntensity: number
+    edgeBlurEnabled: boolean
+    edgeBlurIntensity: number
+    bloomEnabled: boolean
+    bloomIntensity: number
+
     set: (state: Partial<AppState>) => void
 
     // 异步 actions
@@ -68,6 +78,15 @@ export const useStore = create<AppState>((set, get) => ({
     pickedCoord: null,
 
     activeTileId: null,
+
+    vignetteEnabled: true,
+    vignetteIntensity: 0.45,
+    chromaticEnabled: true,
+    chromaticIntensity: 0.003,
+    edgeBlurEnabled: true,
+    edgeBlurIntensity: 0.5,
+    bloomEnabled: true,
+    bloomIntensity: 0.15,
 
     set: (state) => set(state),
 


### PR DESCRIPTION
…cts with debug controls

- Sync highlight vertex wave with base point cloud so both layers float together
- Reduce highlight glow (brightness 1.6→1.15, sweep multiplier 1.5→0.6)
- Fix normal areas whitewashing by raising bloom luminanceThreshold to 1.2
- Add vignette, chromatic aberration (radial), and edge blur (TiltShift) effects
- Add debug panel toggles + intensity sliders for all four effects
- Fix faded cat tile position to correct coordinates