### PR TITLE
feat: highlight sync, post-processing effects, debug controls

### DIFF
--- a/src/components/canvas/HighlightPointCloud.tsx
+++ b/src/components/canvas/HighlightPointCloud.tsx
@@ -25,6 +25,7 @@ export function HighlightPointCloud({
     const hlFullSample = useStore((s) => s.hlFullSample)
     const samplePercent = useStore((s) => s.samplePercent)
     const pointSize = useStore((s) => s.pointSize)
+    const hlGlowIntensity = useStore((s) => s.hlGlowIntensity)
 
 
     const effectiveSample = hlFullSample ? 100 : samplePercent
@@ -86,6 +87,7 @@ export function HighlightPointCloud({
             materialRef.current.uniforms.uTime.value = state.clock.getElapsedTime()
             materialRef.current.uniforms.uPixelRatio.value = state.gl.getPixelRatio()
             materialRef.current.uniforms.uSize.value = pointSize
+            materialRef.current.uniforms.uBrightness.value = hlGlowIntensity
         }
     })
 

--- a/src/components/canvas/HighlightShaderMaterial.tsx
+++ b/src/components/canvas/HighlightShaderMaterial.tsx
@@ -7,7 +7,7 @@ const HighlightShaderMaterial = shaderMaterial(
     uTime: 0,
     uPixelRatio: 1,
     uSize: 0.5,
-    uBrightness: 1.15,      // color boost (subtle — keeps original hue)
+    uBrightness: 0.35,      // low base for additive — glow comes from blending, not brightness
     uSweepSpeed: 0.8,       // how fast the light band sweeps
     uSweepWidth: 2.0,       // width of the sweep band
   },
@@ -76,7 +76,7 @@ const HighlightShaderMaterial = shaderMaterial(
 
       // Base highlight: original color * brightness
       // Sweep adds extra glow on top
-      float totalBright = uBrightness + sweepIntensity * 0.6;
+      float totalBright = uBrightness + sweepIntensity * 0.4;
       vec3 glowColor = vColor * totalBright;
 
       // Soft edge for additive blending

--- a/src/components/canvas/HighlightShaderMaterial.tsx
+++ b/src/components/canvas/HighlightShaderMaterial.tsx
@@ -7,7 +7,7 @@ const HighlightShaderMaterial = shaderMaterial(
     uTime: 0,
     uPixelRatio: 1,
     uSize: 0.5,
-    uBrightness: 0.35,      // low base for additive — glow comes from blending, not brightness
+    uBrightness: 1.15,      // color boost (subtle — keeps original hue)
     uSweepSpeed: 0.8,       // how fast the light band sweeps
     uSweepWidth: 2.0,       // width of the sweep band
   },
@@ -76,7 +76,7 @@ const HighlightShaderMaterial = shaderMaterial(
 
       // Base highlight: original color * brightness
       // Sweep adds extra glow on top
-      float totalBright = uBrightness + sweepIntensity * 0.4;
+      float totalBright = uBrightness + sweepIntensity * 0.6;
       vec3 glowColor = vColor * totalBright;
 
       // Soft edge for additive blending

--- a/src/components/canvas/Scene.tsx
+++ b/src/components/canvas/Scene.tsx
@@ -2,7 +2,7 @@
 
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
-import { EffectComposer, Bloom, Vignette, ChromaticAberration, TiltShift } from '@react-three/postprocessing'
+import { EffectComposer, Vignette, ChromaticAberration, TiltShift } from '@react-three/postprocessing'
 import { BlendFunction } from 'postprocessing'
 import * as THREE from 'three'
 import { Suspense, Component, type ReactNode } from 'react'
@@ -47,8 +47,6 @@ function SceneContent() {
     const chromaticIntensity = useStore((s) => s.chromaticIntensity)
     const edgeBlurEnabled = useStore((s) => s.edgeBlurEnabled)
     const edgeBlurIntensity = useStore((s) => s.edgeBlurIntensity)
-    const bloomEnabled = useStore((s) => s.bloomEnabled)
-    const bloomIntensity = useStore((s) => s.bloomIntensity)
     const activeMemory = memories.find((m) => m.id === activeMemoryId)
 
     if (!activeMemory || !activeMemory.model_url) return null
@@ -79,12 +77,6 @@ function SceneContent() {
                 />
             ))}
             <EffectComposer>
-                <Bloom
-                    intensity={bloomEnabled ? bloomIntensity : 0}
-                    luminanceThreshold={1.2}
-                    luminanceSmoothing={0.4}
-                    mipmapBlur
-                />
                 <Vignette
                     offset={0.3}
                     darkness={vignetteEnabled ? vignetteIntensity : 0}

--- a/src/components/dom/DebugPanel.tsx
+++ b/src/components/dom/DebugPanel.tsx
@@ -22,6 +22,7 @@ export function DebugPanel() {
         chromaticIntensity,
         edgeBlurEnabled,
         edgeBlurIntensity,
+        hlGlowIntensity,
         set,
     } = useStore((s) => s)
 
@@ -113,6 +114,17 @@ export function DebugPanel() {
                         {/* Effects */}
                         <div className="px-4 py-3 space-y-4 border-b border-white/5">
                             <span className="text-[10px] text-white/30 uppercase tracking-widest">Effects</span>
+
+                            {/* HL Glow */}
+                            <SliderControl
+                                label="HL Glow"
+                                value={hlGlowIntensity}
+                                min={0.1}
+                                max={3.0}
+                                step={0.05}
+                                displayValue={hlGlowIntensity.toFixed(2)}
+                                onChange={(v) => set({ hlGlowIntensity: v })}
+                            />
 
                             {/* Vignette */}
                             <EffectControl

--- a/src/components/dom/DebugPanel.tsx
+++ b/src/components/dom/DebugPanel.tsx
@@ -22,8 +22,6 @@ export function DebugPanel() {
         chromaticIntensity,
         edgeBlurEnabled,
         edgeBlurIntensity,
-        bloomEnabled,
-        bloomIntensity,
         set,
     } = useStore((s) => s)
 
@@ -115,19 +113,6 @@ export function DebugPanel() {
                         {/* Effects */}
                         <div className="px-4 py-3 space-y-4 border-b border-white/5">
                             <span className="text-[10px] text-white/30 uppercase tracking-widest">Effects</span>
-
-                            {/* Bloom */}
-                            <EffectControl
-                                label="Bloom"
-                                enabled={bloomEnabled}
-                                onToggle={() => set({ bloomEnabled: !bloomEnabled })}
-                                value={bloomIntensity}
-                                min={0.01}
-                                max={1.0}
-                                step={0.01}
-                                displayValue={bloomIntensity.toFixed(2)}
-                                onChange={(v) => set({ bloomIntensity: v })}
-                            />
 
                             {/* Vignette */}
                             <EffectControl

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -42,8 +42,6 @@ interface AppState {
     chromaticIntensity: number
     edgeBlurEnabled: boolean
     edgeBlurIntensity: number
-    bloomEnabled: boolean
-    bloomIntensity: number
 
     set: (state: Partial<AppState>) => void
 
@@ -85,9 +83,6 @@ export const useStore = create<AppState>((set, get) => ({
     chromaticIntensity: 0.003,
     edgeBlurEnabled: true,
     edgeBlurIntensity: 0.5,
-    bloomEnabled: false,
-    bloomIntensity: 0.15,
-
     set: (state) => set(state),
 
     // 从 API 获取所有 memories

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -85,7 +85,7 @@ export const useStore = create<AppState>((set, get) => ({
     chromaticIntensity: 0.003,
     edgeBlurEnabled: true,
     edgeBlurIntensity: 0.5,
-    bloomEnabled: true,
+    bloomEnabled: false,
     bloomIntensity: 0.15,
 
     set: (state) => set(state),

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -35,6 +35,9 @@ interface AppState {
     // Info tiles
     activeTileId: string | null
 
+    // Highlight glow
+    hlGlowIntensity: number
+
     // Post-processing effects
     vignetteEnabled: boolean
     vignetteIntensity: number
@@ -76,6 +79,8 @@ export const useStore = create<AppState>((set, get) => ({
     pickedCoord: null,
 
     activeTileId: null,
+
+    hlGlowIntensity: 1.15,
 
     vignetteEnabled: true,
     vignetteIntensity: 0.45,


### PR DESCRIPTION
## Summary
- **Highlight sync**: Added matching wave animation to highlight vertex shader so it floats in sync with the base point cloud
- **Glow tuning**: Reduced highlight brightness (1.6→1.15) and sweep multiplier (1.5→0.6); added real-time HL Glow slider in debug panel
- **Removed full-screen Bloom**: Bloom post-processing was washing out normal areas — highlight shader's AdditiveBlending provides its own glow
- **Post-processing effects**: Added Vignette (edge darkening), ChromaticAberration (radial, stronger at edges), TiltShift (edge blur with sharp center)
- **Debug controls**: New Effects section with per-effect toggle + intensity slider (HL Glow, Vignette, Chromatic, Edge Blur)
- **Label fix**: Corrected faded cat / Cat Scratches tile position to [0.5196, -0.1707, -0.3407]

## Test plan
- [ ] Open detail view, confirm highlight and base cloud animate together
- [ ] Adjust HL Glow slider — highlight brightness should change in real time
- [ ] Verify normal (non-highlight) areas have proper color, no whitewash
- [ ] Toggle each effect on/off in debug panel, adjust sliders
- [ ] Navigate to faded cat project, confirm Cat Scratches label at correct position

🤖 Generated with [Claude Code](https://claude.com/claude-code)